### PR TITLE
[Leetcode][Medium] 71. Simplify Path

### DIFF
--- a/internal/slices/slices.go
+++ b/internal/slices/slices.go
@@ -1,0 +1,7 @@
+package slices
+
+func Reverse[T any](s []T) {
+	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
+		s[i], s[j] = s[j], s[i]
+	}
+}

--- a/internal/slices/slices_test.go
+++ b/internal/slices/slices_test.go
@@ -1,0 +1,29 @@
+package slices
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReverse(t *testing.T) {
+	tests := []struct {
+		in  []any
+		out []any
+	}{
+		{
+			in:  []any{1, 2, 3},
+			out: []any{3, 2, 1},
+		},
+		{
+			in:  []any{"a", "b", "c"},
+			out: []any{"c", "b", "a"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			Reverse(tt.in)
+			assert.Equal(t, tt.out, tt.in)
+		})
+	}
+}

--- a/internal/stack/array_stack.go
+++ b/internal/stack/array_stack.go
@@ -1,0 +1,47 @@
+package stack
+
+type ArrayStack[T any] struct {
+	data []T
+	cap  int
+}
+
+func NewArrayStack[T any](cap int) Stack[T] {
+	return &ArrayStack[T]{
+		data: make([]T, 0, cap),
+		cap:  cap,
+	}
+}
+
+func (s *ArrayStack[T]) Push(v T) {
+	s.data = append(s.data, v)
+}
+
+func (s *ArrayStack[T]) Pop() (v T) {
+	if len(s.data) == 0 {
+		return v
+	}
+	idx := len(s.data) - 1
+	v = s.data[idx]
+	s.data = s.data[:idx]
+	return v
+}
+
+func (s *ArrayStack[T]) Clear() {
+	s.data = make([]T, 0, s.cap)
+}
+
+func (s *ArrayStack[T]) Peek() (v T) {
+	if len(s.data) == 0 {
+		return v
+	}
+	idx := len(s.data) - 1
+	return s.data[idx]
+}
+
+func (s *ArrayStack[T]) Len() int {
+	return len(s.data)
+}
+
+func (s *ArrayStack[T]) All() []T {
+	return s.data
+}

--- a/internal/stack/array_stack_test.go
+++ b/internal/stack/array_stack_test.go
@@ -1,0 +1,34 @@
+package stack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestArrayStack(t *testing.T) {
+	s := NewArrayStack[int](3)
+	s.Push(1)
+	s.Push(2)
+	s.Push(3)
+	assert.Equal(t, 3, s.Len())
+	assert.Equal(t, []int{1, 2, 3}, s.All())
+	assert.Equal(t, 3, s.Peek())
+	assert.Equal(t, 3, s.Pop())
+	assert.Equal(t, 2, s.Len())
+	assert.Equal(t, []int{1, 2}, s.All())
+	assert.Equal(t, 2, s.Peek())
+	assert.Equal(t, 2, s.Pop())
+	assert.Equal(t, 1, s.Len())
+	assert.Equal(t, []int{1}, s.All())
+	assert.Equal(t, 1, s.Peek())
+	assert.Equal(t, 1, s.Pop())
+	assert.Equal(t, 0, s.Len())
+	assert.Equal(t, []int{}, s.All())
+	assert.Equal(t, 0, s.Peek())
+	assert.Equal(t, 0, s.Pop())
+	s.Push(1)
+	assert.Equal(t, 1, s.Len())
+	s.Clear()
+	assert.Equal(t, 0, s.Len())
+}

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -1,0 +1,10 @@
+package stack
+
+type Stack[T any] interface {
+	Push(v T)
+	Pop() T
+	Peek() T
+	Clear()
+	Len() int
+	All() []T
+}

--- a/leetcode/problems/medium/simplify_path.go
+++ b/leetcode/problems/medium/simplify_path.go
@@ -1,0 +1,26 @@
+package medium
+
+import (
+	"strings"
+
+	"github.com/lovung/challenges/internal/stack"
+)
+
+const sep = "/"
+
+// Link: https://leetcode.com/problems/simplify-path/
+func simplifyPath(path string) string {
+	pathStack := stack.NewArrayStack[string](100)
+	paths := strings.Split(path, sep)
+	for _, p := range paths {
+		switch p {
+		case ".", "":
+			continue
+		case "..":
+			pathStack.Pop()
+		default:
+			pathStack.Push(p)
+		}
+	}
+	return sep + strings.Join(pathStack.All(), sep)
+}

--- a/leetcode/problems/medium/simplify_path_test.go
+++ b/leetcode/problems/medium/simplify_path_test.go
@@ -1,0 +1,57 @@
+package medium
+
+import "testing"
+
+func Test_simplifyPath(t *testing.T) {
+	type args struct {
+		path string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "test1",
+			args: args{
+				path: "/home/",
+			},
+			want: "/home",
+		},
+		{
+			name: "test2",
+			args: args{
+				path: "/a/./b/../../c/",
+			},
+			want: "/c",
+		},
+		{
+			name: "test3",
+			args: args{
+				path: "/a/../../b/../c//.//",
+			},
+			want: "/c",
+		},
+		{
+			name: "test4",
+			args: args{
+				path: "/../",
+			},
+			want: "/",
+		},
+		{
+			name: "test5",
+			args: args{
+				path: "/home//foo/",
+			},
+			want: "/home/foo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := simplifyPath(tt.args.path); got != tt.want {
+				t.Errorf("simplifyPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Given a string path, which is an absolute path (starting with a slash '/') to a file or directory in a Unix-style file system, convert it to the simplified canonical path.

In a Unix-style file system, a period '.' refers to the current directory, a double period '..' refers to the directory up a level, and any multiple consecutive slashes (i.e. '//') are treated as a single slash '/'. For this problem, any other format of periods such as '...' are treated as file/directory names.

The canonical path should have the following format:

The path starts with a single slash '/'.
Any two directories are separated by a single slash '/'.
The path does not end with a trailing '/'.
The path only contains the directories on the path from the root directory to the target file or directory (i.e., no period '.' or double period '..')
Return the simplified canonical path.

Example 1:
```
Input: path = "/home/"
Output: "/home"
Explanation: Note that there is no trailing slash after the last directory name.
```
Example 2:
```
Input: path = "/../"
Output: "/"
Explanation: Going one level up from the root directory is a no-op, as the root level is the highest level you can go.
```
Example 3:
```
Input: path = "/home//foo/"
Output: "/home/foo"
Explanation: In the canonical path, multiple consecutive slashes are replaced by a single one.
 ```

Constraints:
* 1 <= path.length <= 3000
* path consists of English letters, digits, period '.', slash '/' or '_'.
* path is a valid absolute Unix path.