### PR TITLE
[Leetcode][Medium] 31. Next Permutation

### DIFF
--- a/internal/heaps/min_heap_with_value.go
+++ b/internal/heaps/min_heap_with_value.go
@@ -1,0 +1,29 @@
+package heaps
+
+import "golang.org/x/exp/constraints"
+
+type HeapItem[T constraints.Ordered] struct {
+	Ref   T
+	Value any
+}
+
+// An MinHeapWithValue is a min-heap of ints.
+type MinHeapWithValue[T constraints.Ordered] []HeapItem[T]
+
+func (h MinHeapWithValue[T]) Len() int           { return len(h) }
+func (h MinHeapWithValue[T]) Less(i, j int) bool { return h[i].Ref < h[j].Ref }
+func (h MinHeapWithValue[T]) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+
+// Push to heap
+func (h *MinHeapWithValue[T]) Push(x any) {
+	*h = append(*h, x.(HeapItem[T]))
+}
+
+// Pop from heap
+func (h *MinHeapWithValue[T]) Pop() any {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}

--- a/internal/heaps/min_heap_with_value_test.go
+++ b/internal/heaps/min_heap_with_value_test.go
@@ -1,0 +1,20 @@
+package heaps
+
+import (
+	"container/heap"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMinHeapWithValue(t *testing.T) {
+	var h MinHeapWithValue[int]
+	heap.Init(&h)
+	heap.Push(&h, HeapItem[int]{Ref: 3, Value: 3})
+	heap.Push(&h, HeapItem[int]{Ref: 1, Value: 1})
+	heap.Push(&h, HeapItem[int]{Ref: 2, Value: 2})
+	assert.Equal(t, 3, h.Len())
+	assert.Equal(t, 1, heap.Pop(&h).(HeapItem[int]).Value.(int))
+	assert.Equal(t, 2, heap.Pop(&h).(HeapItem[int]).Ref)
+	assert.Equal(t, 1, h.Len())
+}

--- a/leetcode/problems/medium/next_permutation.go
+++ b/leetcode/problems/medium/next_permutation.go
@@ -1,0 +1,58 @@
+package medium
+
+import (
+	"container/heap"
+	"sort"
+
+	"github.com/lovung/challenges/internal/heaps"
+)
+
+// Link: https://leetcode.com/problems/next-permutation
+/*
+	A permutation of an array of integers is an arrangement of its members into a sequence or linear order.
+
+	For example, for arr = [1,2,3], the following are considered permutations of arr: [1,2,3], [1,3,2], [3,1,2], [2,3,1].
+	The next permutation of an array of integers is the next lexicographically greater permutation of its integer. More formally, if all the permutations of the array are sorted in one container according to their lexicographical order, then the next permutation of that array is the permutation that follows it in the sorted container. If such arrangement is not possible, the array must be rearranged as the lowest possible order (i.e., sorted in ascending order).
+
+	For example, the next permutation of arr = [1,2,3] is [1,3,2].
+	Similarly, the next permutation of arr = [2,3,1] is [3,1,2].
+	While the next permutation of arr = [3,2,1] is [1,2,3] because [3,2,1] does not have a lexicographical larger rearrangement.
+	Given an array of integers nums, find the next permutation of nums.
+
+	[1, 2, 3] -> [1, 3, 2]
+	[1, 3, 2] -> [2, 1, 3]
+	[2, 1, 3] -> [2, 3, 1]
+	[2, 3, 1] -> [3, 1, 2]
+	[3, 1, 2] -> [3, 2, 1]
+	[3, 2, 1] -> [1, 2, 3]
+
+	[4, 1, 3, 2] -> [4, 2, 1, 3]
+	[4, 0, 1, 3, 2] -> [4, 0, 2, 1, 3]
+
+
+	[5,4,7,5,3,2]
+
+	The replacement must be in place and use only constant extra memory.
+*/
+func nextPermutation(nums []int) {
+	h := heaps.MinHeapWithValue[int]{}
+	heap.Init(&h)
+	for i := len(nums) - 1; i > 0; i-- {
+		item := heaps.HeapItem[int]{
+			Ref:   nums[i],
+			Value: i,
+		}
+		heap.Push(&h, item)
+		if nums[i-1] < nums[i] {
+			minValue := heap.Pop(&h)
+			for minValue != nil && minValue.(heaps.HeapItem[int]).Ref <= nums[i-1] {
+				minValue = heap.Pop(&h)
+			}
+			gotcha := minValue.(heaps.HeapItem[int])
+			nums[i-1], nums[gotcha.Value.(int)] = nums[gotcha.Value.(int)], nums[i-1]
+			sort.Ints(nums[i:])
+			return
+		}
+	}
+	sort.Ints(nums)
+}

--- a/leetcode/problems/medium/next_permutation_test.go
+++ b/leetcode/problems/medium/next_permutation_test.go
@@ -1,0 +1,81 @@
+package medium
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_nextPermutation(t *testing.T) {
+	type args struct {
+		nums []int
+	}
+	tests := []struct {
+		name string
+		args args
+		want []int
+	}{
+		{
+			name: "[5,4,7,5,3,2]",
+			args: args{
+				nums: []int{5, 4, 7, 5, 3, 2},
+			},
+			want: []int{5, 5, 2, 3, 4, 7},
+		},
+		{
+			name: "[1, 2, 3]",
+			args: args{
+				nums: []int{1, 2, 3},
+			},
+			want: []int{1, 3, 2},
+		},
+		{
+			name: "[1, 3, 2]",
+			args: args{
+				nums: []int{1, 3, 2},
+			},
+			want: []int{2, 1, 3},
+		},
+		{
+			name: "[2, 3, 1]",
+			args: args{
+				nums: []int{2, 3, 1},
+			},
+			want: []int{3, 1, 2},
+		},
+		{
+			name: "[3, 2, 1]",
+			args: args{
+				nums: []int{3, 2, 1},
+			},
+			want: []int{1, 2, 3},
+		},
+		{
+			name: "[1, 1, 5]",
+			args: args{
+				nums: []int{1, 1, 5},
+			},
+			want: []int{1, 5, 1},
+		},
+		{
+			name: "[1, 5, 1]",
+			args: args{
+				nums: []int{1, 5, 1},
+			},
+			want: []int{5, 1, 1},
+		},
+		{
+			name: "[1, 9, 8, 12, 3]",
+			args: args{
+				nums: []int{1, 9, 8, 12, 3},
+			},
+			want: []int{1, 9, 12, 3, 8},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nextPermutation(tt.args.nums)
+			assert.Equal(t, tt.want, tt.args.nums)
+		})
+	}
+}


### PR DESCRIPTION
A permutation of an array of integers is an arrangement of its members into a sequence or linear order.

For example, for arr = `[1,2,3]`, the following are considered permutations of arr: `[1,2,3], [1,3,2], [3,1,2], [3,2,1], [2,3,1], [2,1,3]`.
The next permutation of an array of integers is the next lexicographically greater permutation of its integer. More formally, if all the permutations of the array are sorted in one container according to their lexicographical order, then the next permutation of that array is the permutation that follows it in the sorted container. If such arrangement is not possible, the array must be rearranged as the lowest possible order (i.e., sorted in ascending order).

For example, the next permutation of arr = `[1,2,3]` is `[1,3,2]`.
Similarly, the next permutation of arr = `[2,3,1]` is `[3,1,2]`.
While the next permutation of arr = `[3,2,1]` is `[1,2,3]` because `[3,2,1]` does not have a lexicographical larger rearrangement.
Given an array of integers nums, find the next permutation of nums.

The replacement must be [in place](http://en.wikipedia.org/wiki/In-place_algorithm) and use only constant extra memory.

 

Example 1:
```
Input: nums = [1,2,3]
Output: [1,3,2]
```
Example 2:
```
Input: nums = [3,2,1]
Output: [1,2,3]
```
Example 3:
```
Input: nums = [1,1,5]
Output: [1,5,1]
 ```

Constraints:
* `1 <= nums.length <= 100`
* `0 <= nums[i] <= 100`