### PR TITLE
[Leetcode][Medium] 1753. Maximum Score From Removing Stones

### DIFF
--- a/leetcode/problems/medium/maximum_score_from_removing_stones.go
+++ b/leetcode/problems/medium/maximum_score_from_removing_stones.go
@@ -1,0 +1,18 @@
+package medium
+
+// Link: https://leetcode.com/problems/maximum-score-from-removing-stones/
+func maximumScore(a int, b int, c int) int {
+	// bubble sort
+	if a > b {
+		a, b = b, a
+	}
+	if b > c {
+		b, c = c, b
+	}
+
+	// triagle rule check
+	if a+b < c {
+		return a + b
+	}
+	return (a + b + c) / 2
+}

--- a/leetcode/problems/medium/maximum_score_from_removing_stones_test.go
+++ b/leetcode/problems/medium/maximum_score_from_removing_stones_test.go
@@ -1,0 +1,59 @@
+package medium
+
+import "testing"
+
+func Test_maximumScore(t *testing.T) {
+	type args struct {
+		a int
+		b int
+		c int
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			name: "test1",
+			args: args{2, 4, 6},
+			want: 6,
+		},
+		{
+			name: "test2",
+			args: args{1, 3, 2},
+			want: 3,
+		},
+		{
+			name: "test3",
+			args: args{4, 4, 6},
+			want: 7,
+		},
+		{
+			name: "test4",
+			args: args{6, 2, 1},
+			want: 3,
+		},
+		{
+			name: "test5",
+			args: args{6, 1, 2},
+			want: 3,
+		},
+		{
+			name: "test6",
+			args: args{2, 3, 1},
+			want: 3,
+		},
+		{
+			name: "test7",
+			args: args{2, 1, 3},
+			want: 3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := maximumScore(tt.args.a, tt.args.b, tt.args.c); got != tt.want {
+				t.Errorf("maximumScore() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
https://leetcode.com/problems/maximum-score-from-removing-stones/

You are playing a solitaire game with three piles of stones of sizes a​​​​​​, b,​​​​​​ and c​​​​​​ respectively. Each turn you choose two different non-empty piles, take one stone from each, and add 1 point to your score. The game stops when there are fewer than two non-empty piles (meaning there are no more available moves).

Given three integers a​​​​​, b,​​​​​ and c​​​​​, return the maximum score you can get.

Example 1:
```
Input: a = 2, b = 4, c = 6
Output: 6
Explanation: The starting state is (2, 4, 6). One optimal set of moves is:
- Take from 1st and 3rd piles, state is now (1, 4, 5)
- Take from 1st and 3rd piles, state is now (0, 4, 4)
- Take from 2nd and 3rd piles, state is now (0, 3, 3)
- Take from 2nd and 3rd piles, state is now (0, 2, 2)
- Take from 2nd and 3rd piles, state is now (0, 1, 1)
- Take from 2nd and 3rd piles, state is now (0, 0, 0)
There are fewer than two non-empty piles, so the game ends. Total: 6 points.
```
Example 2:
```
Input: a = 4, b = 4, c = 6
Output: 7
Explanation: The starting state is (4, 4, 6). One optimal set of moves is:
- Take from 1st and 2nd piles, state is now (3, 3, 6)
- Take from 1st and 3rd piles, state is now (2, 3, 5)
- Take from 1st and 3rd piles, state is now (1, 3, 4)
- Take from 1st and 3rd piles, state is now (0, 3, 3)
- Take from 2nd and 3rd piles, state is now (0, 2, 2)
- Take from 2nd and 3rd piles, state is now (0, 1, 1)
- Take from 2nd and 3rd piles, state is now (0, 0, 0)
There are fewer than two non-empty piles, so the game ends. Total: 7 points.
```
Example 3:
```
Input: a = 1, b = 8, c = 8
Output: 8
Explanation: One optimal set of moves is to take from the 2nd and 3rd piles for 8 turns until they are empty.
After that, there are fewer than two non-empty piles, so the game ends.
```

Constraints:
* `1 <= a, b, c <= 105`